### PR TITLE
fix: sfimage fix in story, add progressive lazy loading with story

### DIFF
--- a/packages/vue/src/components/atoms/SfImage/SfImage.stories.js
+++ b/packages/vue/src/components/atoms/SfImage/SfImage.stories.js
@@ -6,7 +6,7 @@ import {
   number,
   object,
 } from "@storybook/addon-knobs";
-import { SfImage } from "@storefront-ui/vue";
+import { SfImage, SfArrow } from "@storefront-ui/vue";
 storiesOf("Atoms|Image", module)
   .addDecorator(withKnobs)
   .add("Common", () => ({
@@ -128,7 +128,6 @@ storiesOf("Atoms|Image", module)
     },
     template: `<SfImage
         :src="src"
-        :srcset="srcset"
         :alt="alt"
         :lazy="lazy"
         :rootMargin="rootMargin"
@@ -206,6 +205,71 @@ storiesOf("Atoms|Image", module)
         :rootMargin="rootMargin"
         :threshold="threshold"
       />`,
+	}))
+	.add("With progressive loading", () => ({
+    components: { SfImage, SfArrow },
+    props: {
+      srcset: {
+        default: object(
+          "srcset",
+          [
+            {
+              src: `/assets/storybook/SfImage/product-109x164.webp`,
+              media: `(max-width: 480px)`,
+              type: `image/webp`,
+            },
+            {
+              src: `/assets/storybook/SfImage/product-109x164.webp`,
+              media: `(min-width: 480px) and (max-width: 720px)`,
+              type: `image/webp`,
+            },
+            {
+              src: `/assets/storybook/SfImage/product-216x326.jpg`,
+              media: `(min-width: 1240px)`,
+              type: `image/jpg`,
+            },
+          ],
+          "Props"
+        ),
+      },
+      src: {
+        default: text(
+          "src",
+          "/assets/storybook/SfImage/placeholder.png",
+          "Props"
+        ),
+      },
+      alt: {
+        default: text("alt", "Vila stripe maxi shirt dress", "Props"),
+      },
+      width: {
+        default: number("width", 216, {}, "Props"),
+      },
+      height: {
+        default: number("height", 326, {}, "Props"),
+      },
+      lazy: {
+        default: boolean("lazy", true, "Props"),
+      },
+      rootMargin: {
+        default: text("rootMargin", "", "Props"),
+      },
+      threshold: {
+        default: number("threshold", 0.5, {}, "Props"),
+      },
+    },
+    template: `
+    <div>
+      <SfArrow class="sf-arrow--down" style="margin: 20vh auto 100vh auto"/>
+      <SfImage
+          :src="src"
+          :srcset="srcset"
+          :alt="alt"
+          :lazy="lazy"
+          :rootMargin="rootMargin"
+          :threshold="threshold"
+        />
+    </div>`,
   }))
   .add("[slot] default", () => ({
     components: { SfImage },

--- a/packages/vue/src/components/atoms/SfImage/SfImage.vue
+++ b/packages/vue/src/components/atoms/SfImage/SfImage.vue
@@ -104,7 +104,7 @@ export default {
       if (this.isLazyAndNotLoaded) {
         return {
           srcset: [{ media: null, src: null, type: null }],
-          src: "",
+          src: this.src,
         };
       }
       // TODO: To be removed if src as an object will not be available anymore


### PR DESCRIPTION
# Related issue
no
# Scope of work
SfImage - add progressive lazy loading story and change code accordingly, fix story "with src" removing "srcset" property.


# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
